### PR TITLE
Fix GL_INVALID_OPERATION error from glClearBufferData

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ SRCS := $(shell find $(SRC_DIRS) -name *.c)
 OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
+CFLAGS := -g -O3
+
 INC_DIRS := $(shell find $(SRC_DIRS) -type d)
 INC_DIRS += ./dependencies/include
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))

--- a/src/DoonEngine/voxel.c
+++ b/src/DoonEngine/voxel.c
@@ -122,7 +122,7 @@ DNmap* DN_create_map(DNuvec3 mapSize, DNuvec2 textureSize, bool streamable, unsi
 		return NULL;
 	}
 	glBindBuffer(GL_SHADER_STORAGE_BUFFER, map->glMapBufferID);
-	glClearBufferData(GL_SHADER_STORAGE_BUFFER, GL_R32UI, GL_RED, GL_UNSIGNED_INT, NULL);
+	glClearBufferData(GL_SHADER_STORAGE_BUFFER, GL_R8, GL_RED, GL_UNSIGNED_BYTE, NULL);
 
 	size_t numChunks;
 	if(streamable)
@@ -136,7 +136,7 @@ DNmap* DN_create_map(DNuvec3 mapSize, DNuvec2 textureSize, bool streamable, unsi
 		return NULL;
 	}
 	glBindBuffer(GL_SHADER_STORAGE_BUFFER, map->glChunkBufferID);
-	glClearBufferData(GL_SHADER_STORAGE_BUFFER, GL_R32UI, GL_RED, GL_UNSIGNED_INT, NULL);
+	glClearBufferData(GL_SHADER_STORAGE_BUFFER, GL_R8, GL_RED, GL_UNSIGNED_BYTE, NULL);
 
 	//allocate CPU memory:
 	//---------------------------------


### PR DESCRIPTION
On my machine, for whatever reason glClearBufferData was producing invalid operation errors. I ran the engine w/o the glClearBufferData calls and it worked just fine, but in the interest of stability / avoiding UB, I switched over the formats to being bytes rather than unsigned ints. For whatever reason, this got rid of the error, and the end result is the same (setting the contents of the buffer to 0).