### PR TITLE
Use projection / view matrices for ray generation, bug fixes

### DIFF
--- a/assets/shaders/voxelDraw.comp
+++ b/assets/shaders/voxelDraw.comp
@@ -29,13 +29,15 @@ void main()
 	bool voxelHit;			//whether or not a voxel was hit
 
 	//calculate ray position and direction:
-	vec2 screenPos;
-	screenPos.x = gl_GlobalInvocationID.x / (float(gl_NumWorkGroups.x) * 8.0) - 1.0; //(0,0) at the center of the screen
-	screenPos.y = gl_GlobalInvocationID.y / (float(gl_NumWorkGroups.y) * 8.0) - 1.0;
+	ivec2 coords = ivec2(gl_GlobalInvocationID.xy);
+	vec2 screenPos = coords / vec2(imageSize(colorOutput)) * 2.0 - 1.0;
 
+	mat4 invViewMat = inverse(viewMat);
+	mat4 invProjectionMat = inverse(projectionMat);
+
+	vec3 rayPos = (invViewMat * vec4(0.0, 0.0, 0.0, 1.0)).xyz;
 	vec3 rayDir = camDir + screenPos.x * camPlaneU + screenPos.y * camPlaneV;
 	vec3 invRayDir = 1.0 / rayDir;
-	vec3 rayPos = camPos;
 
 	//check if ray hits the map at all:
 	vec2 intersection = intersect_AABB(invRayDir, rayPos, vec3(0.0), mapSize);
@@ -118,7 +120,6 @@ void main()
 	}
 
 	//store final color to texture:
-	ivec2 coords = ivec2(gl_GlobalInvocationID.xy);
 	imageStore(colorOutput, coords, vec4(finalColor, 1.0));
 	imageStore(depthOutput, coords, transformedIntersectionPoint);
 }

--- a/assets/shaders/voxelDraw.comp
+++ b/assets/shaders/voxelDraw.comp
@@ -32,11 +32,17 @@ void main()
 	ivec2 coords = ivec2(gl_GlobalInvocationID.xy);
 	vec2 screenPos = coords / vec2(imageSize(colorOutput)) * 2.0 - 1.0;
 
+	mat4 centeredViewMat = viewMat;
+	centeredViewMat[3][0] = 0.0;
+	centeredViewMat[3][1] = 0.0;
+	centeredViewMat[3][2] = 0.0;
+
 	mat4 invViewMat = inverse(viewMat);
 	mat4 invProjectionMat = inverse(projectionMat);
+	mat4 invCenteredViewMat = inverse(centeredViewMat);
 
 	vec3 rayPos = (invViewMat * vec4(0.0, 0.0, 0.0, 1.0)).xyz;
-	vec3 rayDir = camDir + screenPos.x * camPlaneU + screenPos.y * camPlaneV;
+	vec3 rayDir = normalize((invCenteredViewMat * invProjectionMat * vec4(screenPos, 0.0, 1.0)).xyz);
 	vec3 invRayDir = 1.0 / rayDir;
 
 	//check if ray hits the map at all:

--- a/assets/shaders/voxelDraw.comp
+++ b/assets/shaders/voxelDraw.comp
@@ -6,11 +6,6 @@ layout(local_size_x = 16, local_size_y = 16) in; //16x16 local group size
 layout(rgba32f, binding = 0) uniform image2D colorOutput; //the color output texture
 layout(rgba32f, binding = 1) uniform image2D depthOutput; //the depth output texture
 
-uniform vec3 camPos;    //the camera's position
-uniform vec3 camDir;    //the direction the camera is pointing
-uniform vec3 camPlaneU; //the vector that points along the x-axis of the screen
-uniform vec3 camPlaneV; //the vector that points along the y-axis of the screen
-
 uniform uint viewMode;  //what is displayed, 0 = lighting, 1 = albedo, 2 = diffuse light, 3 - specular light, 4 = normals
 
 uniform mat4 viewMat;		//the view matrix used to rasterize any objects, used to determine the depth
@@ -32,6 +27,7 @@ void main()
 	ivec2 coords = ivec2(gl_GlobalInvocationID.xy);
 	vec2 screenPos = coords / vec2(imageSize(colorOutput)) * 2.0 - 1.0;
 
+	//to calculate ray direction, we want to rotate screen space positions according to the view matrix, but not translate them
 	mat4 centeredViewMat = viewMat;
 	centeredViewMat[3][0] = 0.0;
 	centeredViewMat[3][1] = 0.0;

--- a/src/DoonEngine/utility/shader.c
+++ b/src/DoonEngine/utility/shader.c
@@ -32,7 +32,7 @@ int DN_shader_load(GLenum type, const char* path, const char* includePath)
 	int success;
 
 	shader = glCreateShader(type);
-	glShaderSource(shader, 1, &source, NULL);
+	glShaderSource(shader, 1, (const GLchar * const*)&source, NULL);
 	glCompileShader(shader);
 
 	DN_FREE(source);
@@ -152,34 +152,34 @@ void DN_program_uniform_double(GLprogram id, const char* name, GLdouble val)
 	glUniform1d(glGetUniformLocation(id, name), (GLdouble)val);
 }
 
-void DN_program_uniform_vec2(GLprogram id, const char* name, DNvec2 val)
+void DN_program_uniform_vec2(GLprogram id, const char* name, DNvec2* val)
 {
-	glUniform2fv(glGetUniformLocation(id, name), 1, (GLfloat*)&val);
+	glUniform2fv(glGetUniformLocation(id, name), 1, (GLfloat*)val);
 }
 
-void DN_program_uniform_vec3(GLprogram id, const char* name, DNvec3 val)
+void DN_program_uniform_vec3(GLprogram id, const char* name, DNvec3* val)
 {
-	glUniform3fv(glGetUniformLocation(id, name), 1, (GLfloat*)&val);
+	glUniform3fv(glGetUniformLocation(id, name), 1, (GLfloat*)val);
 }
 
-void DN_program_uniform_vec4(GLprogram id, const char* name, DNvec4 val)
+void DN_program_uniform_vec4(GLprogram id, const char* name, DNvec4* val)
 {
-	glUniform4fv(glGetUniformLocation(id, name), 1, (GLfloat*)&val);
+	glUniform4fv(glGetUniformLocation(id, name), 1, (GLfloat*)val);
 }
 
-void DN_program_uniform_mat2(GLprogram id, const char* name, DNmat2 val)
+void DN_program_uniform_mat2(GLprogram id, const char* name, DNmat2* val)
 {
-	glUniformMatrix2fv(glGetUniformLocation(id, name), 1, GL_FALSE, val.m[0]);
+	glUniformMatrix2fv(glGetUniformLocation(id, name), 1, GL_FALSE, (GLfloat*)&val->m[0]);
 }
 
-void DN_program_uniform_mat3(GLprogram id, const char* name, DNmat3 val)
+void DN_program_uniform_mat3(GLprogram id, const char* name, DNmat3* val)
 {
-	glUniformMatrix3fv(glGetUniformLocation(id, name), 1, GL_FALSE, val.m[0]);
+	glUniformMatrix3fv(glGetUniformLocation(id, name), 1, GL_FALSE, (GLfloat*)&val->m[0]);
 }
 
-void DN_program_uniform_mat4(GLprogram id, const char* name, DNmat4 val)
+void DN_program_uniform_mat4(GLprogram id, const char* name, DNmat4* val)
 {
-	glUniformMatrix4fv(glGetUniformLocation(id, name), 1, GL_FALSE, val.m[0]);
+	glUniformMatrix4fv(glGetUniformLocation(id, name), 1, GL_FALSE, (GLfloat*)&val->m[0]);
 }
 
 //--------------------------------------------------------------------------------------------------------------------------------//

--- a/src/DoonEngine/utility/shader.h
+++ b/src/DoonEngine/utility/shader.h
@@ -59,17 +59,17 @@ void DN_program_uniform_float (GLprogram id, const char* name, GLfloat  val);
 void DN_program_uniform_double(GLprogram id, const char* name, GLdouble val);
 
 //Sets a vector2 uniform
-void DN_program_uniform_vec2(GLprogram id, const char* name, DNvec2 val);
+void DN_program_uniform_vec2(GLprogram id, const char* name, DNvec2* val);
 //Sets a vector3 uniform
-void DN_program_uniform_vec3(GLprogram id, const char* name, DNvec3 val);
+void DN_program_uniform_vec3(GLprogram id, const char* name, DNvec3* val);
 //Sets a vector4 uniform
-void DN_program_uniform_vec4(GLprogram id, const char* name, DNvec4 val);
+void DN_program_uniform_vec4(GLprogram id, const char* name, DNvec4* val);
 
 //Sets a 2x2 matrix uniform
-void DN_program_uniform_mat2(GLprogram id, const char* name, DNmat2 val);
+void DN_program_uniform_mat2(GLprogram id, const char* name, DNmat2* val);
 //Sets a 3x3 matrix uniform
-void DN_program_uniform_mat3(GLprogram id, const char* name, DNmat3 val);
+void DN_program_uniform_mat3(GLprogram id, const char* name, DNmat3* val);
 //Sets a 4x4 matrix uniform
-void DN_program_uniform_mat4(GLprogram id, const char* name, DNmat4 val);
+void DN_program_uniform_mat4(GLprogram id, const char* name, DNmat4* val);
 
 #endif

--- a/src/DoonEngine/voxel.h
+++ b/src/DoonEngine/voxel.h
@@ -168,14 +168,21 @@ bool DN_save_map(const char* filePath, DNmap* map);
 //--------------------------------------------------------------------------------------------------------------------------------//
 //DRAWING:
 
-/* Draws the voxel map to the texture
+/* Calculates the view and projection matrices for the current camera position.
  * @param map the map to render
  * @param nearPlane the camera's near clipping plane, used for composing with rasterized objects
  * @param farPlane the camera's far clipping plane, used for composing with rasterized objects
  * @param view populated with the camera's view matrix, use this when rendering rasterized objects
  * @param projection populated with the camera's projection matrix, use this when rendering rasterized objects
  */
-void DN_draw(DNmap* map, float nearPlane, float farPlane, DNmat4* view, DNmat4* projection);
+void DN_set_view_projection_matrices(DNmap* map, float nearPlane, float farPlane, DNmat4* view, DNmat4* projection);
+
+/* Draws the voxel map to the texture
+ * @param map the map to render
+ * @param view the camera's view matrix
+ * @param projection the camera's projection matrix
+ */
+void DN_draw(DNmap* map, DNmat4* view, DNmat4* projection);
 
 /* Updates the lighting on every chunk currently in a map's lightingRequests
  * @param map the map to update

--- a/src/main.c
+++ b/src/main.c
@@ -293,7 +293,9 @@ int main()
 		//draw and update voxels:
 		DNmat4 view;
 		DNmat4 projection;
-		DN_draw(activeMap, 0.1f, 100.0f, &view, &projection);
+		DN_set_view_projection_matrices(activeMap, 0.1f, 100.0f, &view, &projection);
+		
+		DN_draw(activeMap, &view, &projection);
 
 		if(activeMap->streamable)
 			DN_sync_gpu(activeMap, DN_READ_WRITE, DN_REQUEST_VISIBLE, 1);
@@ -316,10 +318,11 @@ int main()
 		DN_program_activate(cubeProgram);
 
 		DNmat4 model = DN_mat4_translate(DN_MAT4_IDENTITY, (DNvec3){5 + 3 * cosf(glfwGetTime()), 1.5 + cosf(glfwGetTime() * 5), 5 + 3 * sinf(glfwGetTime())});
-		DN_program_uniform_mat4(cubeProgram, "modelMat", model);
-		DN_program_uniform_mat4(cubeProgram, "viewMat", view);
-		DN_program_uniform_mat4(cubeProgram, "projectionMat", projection);
-		DN_program_uniform_vec3(cubeProgram, "color", (DNvec3){1.0f, 0.0f, 0.0f});
+		DN_program_uniform_mat4(cubeProgram, "modelMat", &model);
+		DN_program_uniform_mat4(cubeProgram, "viewMat", &view);
+		DN_program_uniform_mat4(cubeProgram, "projectionMat", &projection);
+		DNvec3 color = {1.0f, 0.0f, 0.0f};
+		DN_program_uniform_vec3(cubeProgram, "color", &color);
 
 		glBindVertexArray(cubeVAO);
 		glDrawArrays(GL_TRIANGLES, 0, 36);


### PR DESCRIPTION
In order to properly support rasterization interoperability with voxel ray tracing, rays should be generated using the rasterization view & projections matrices. Additionally, the generation of these matrices should be separated from any draw calls.

Also, I fixed the glUniform calls being made for vectors and matrices. These functions take pointers to vectors and matrices, not vectors or matrices as structs.

The following is not in the scope of this PR, but would rely on the work here.
It would probably be a better idea to rasterize geometry and trace voxels in the same stage, rather than trace voxels in a separate compute shader. This would allow for fewer shader invocations to be called that would need to perform ray tracing, and it would also allow for setting a starting depth of the rays to much farther in the scene. This would also allow for proper handling of transparency. Rather than being a separate pass (where you run into the same issues w/ transparency that deferred shading has, for example), when the voxels are ray traced in the same forward rendering pass as normally rasterized objects, transparency becomes much simpler to handle (can use standard techniques).