### PR TITLE
Modified cmakelists so that dlls and assets are copied over to the build directory with the exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,16 @@ add_executable(${PROJECT_NAME} ${doonengine_src})
 set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "assets/")
 target_link_libraries(${PROJECT_NAME} ${doonengine_lib})
 include_directories("src/" "dependencies/include/")
+
+# Copy DLLs to the build directory
+if(WIN32)
+    add_custom_command(
+        TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/dependencies/lib $<TARGET_FILE_DIR:${PROJECT_NAME}>
+    )
+endif()
+
+# Copy Assets to the build directory
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_directory
+                   ${CMAKE_SOURCE_DIR}/assets $<TARGET_FILE_DIR:${PROJECT_NAME}>)


### PR DESCRIPTION
Just do cmake .. after making a build directory and then build the solution in VS and all necessary files will be copied over like this - 
![image](https://user-images.githubusercontent.com/125090383/231014497-60491502-17ed-4dc5-89b8-2119072286d8.png)
