### PR TITLE
gcc needs -l args at the end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 LD_FLAGS := -lm -lglfw -lGL
 
 $(BUILD_DIR)/$(TARGET_EXEC): $(OBJS)
-	$(CC) $(LD_FLAGS) $(OBJS) -o $@ -march=native
+	$(CC) $(OBJS) -o $@ -march=native $(LD_FLAGS)
 
 $(BUILD_DIR)/%.c.o: %.c
 	$(MKDIR_P) $(dir $@)


### PR DESCRIPTION
Linker was failing for `make` on Ubuntu.

See [this](https://stackoverflow.com/a/9417294) for why the linker fails in this context on Linux